### PR TITLE
Fix #9: remove react-markdown dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "license": "Apache-2.0",
     "peerDependencies": {
         "react": "^17.0.2",
-        "react-dom": "^17.0.2",
-        "react-markdown": "^8.0.3"
+        "react-dom": "^17.0.2"
     },
     "dependencies": {
         "bootstrap": "^5.2.0"

--- a/src/components/asset/MarkdownFileViewer.tsx
+++ b/src/components/asset/MarkdownFileViewer.tsx
@@ -1,25 +1,75 @@
-import React from 'react';
-import ReactMarkdown from 'react-markdown';
+/**
+ *
+ * bedrock - UI Component Library
+ * Copyright (c) 2020, Sandeep Gupta
+ *
+ * https://bedrock.sangupta.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
-interface MarkdownFileViewerProps {
+import React from 'react';
+import { buildCss } from '../../Utils';
+
+interface MarkdownFileViewerProps extends BaseProps {
+
+    /**
+     * The markdown content represented as `string`
+     */
     contents?: string;
+
+    /**
+     * The markdown renderer to use, for example, `react-markdown`.
+     */
+    renderer: any;
+
+    /**
+     * `prop` to use in `renderer` supplied component when sending
+     * markdown. If the value is `null` or `undefined`, content is
+     * passed as `children`.
+     */
+    propName?: string;
 }
 
 /**
- * A Mozilla PDF.js based PDF viewer.
- * Refer https://github.com/mozilla/pdf.js for more details.
- * 
+ * A markdown component that uses an external markdown library
+ * to parse and display contents. For example, you may use
+ * `react-markdown` library and pass its instance to render the
+ * content. This is only a wrapper around the markdown parser
+ * component.
+ *  
  * @author sangupta
  */
 export default class MarkdownFileViewer extends React.Component<MarkdownFileViewerProps> {
 
-    render() {
-        const { contents } = this.props;
+    render(): React.ReactNode {
+        const { contents, renderer, propName, className, ...extraProps } = this.props;
         if (!contents) {
             return null;
         }
 
-        return <ReactMarkdown children={contents} />
+        const props = {};
+        if (propName) {
+            props[propName] = contents;
+        }
+        const kids = propName ? null : contents;
+
+        const Element: any = React.createElement(renderer, props, kids);
+
+        return <div className={buildCss('markdown-content', className)} {...extraProps}>
+            <Element />
+        </div>
     }
 
 }


### PR DESCRIPTION
This PR removes the dependency from `react-markdown` and uses the instance as a `prop`.